### PR TITLE
Port benchmarks to Criterion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,10 @@ repository = "http://github.com/ejmahler/transpose"
 documentation = "http://docs.rs/transpose"
 keywords = ["array", "transpose", "2d"]
 categories = ["algorithms", "data structures"]
+
+[dev-dependencies]
+criterion = "0.2"
+
+[[bench]]
+name = "transpose_benchmarks"
+harness = false

--- a/benches/transpose_benchmarks.rs
+++ b/benches/transpose_benchmarks.rs
@@ -1,44 +1,32 @@
-#![feature(test)]
-extern crate test;
+#[macro_use]
+extern crate criterion;
 
 extern crate transpose;
 
-fn bench_transpose<T: Copy + Default>(b: &mut test::Bencher, width: usize, height: usize) {
-    
-    let mut buffer = vec![T::default(); width * height];
-    let mut scratch = vec![T::default(); width * height];
+use criterion::{Criterion, ParameterizedBenchmark, Throughput};
+use std::mem;
 
-    b.iter(|| { transpose::transpose(&mut buffer, &mut scratch, width, height); });
+fn bench_transpose<T: Copy + Default>(c: &mut Criterion, tyname: &str) {
+    let ref sizes = [(4, 4), (8, 8), (16, 16), (64, 64), (256, 256), (1024, 1024), (4096, 4096)];
+
+    let bench = ParameterizedBenchmark::new(
+        format!("transpose {}", tyname),
+        |b, &&(width, height)| {
+            let mut buffer = vec![T::default(); width * height];
+            let mut scratch = vec![T::default(); width * height];
+
+            b.iter(|| { transpose::transpose(&mut buffer, &mut scratch, width, height); });
+        },
+        sizes)
+        .throughput(|&&(width, height)| Throughput::Bytes((width * height * mem::size_of::<T>()) as u32));
+
+    c.bench("square transposes", bench);
 }
 
-#[bench] fn bench1_u8_0004x0004(b: &mut test::Bencher) { bench_transpose::<u8>(b, 4, 4); }
-#[bench] fn bench1_u8_0008x0008(b: &mut test::Bencher) { bench_transpose::<u8>(b, 8, 8); }
-#[bench] fn bench1_u8_0016x0016(b: &mut test::Bencher) { bench_transpose::<u8>(b, 16, 16); }
-#[bench] fn bench1_u8_0064x0064(b: &mut test::Bencher) { bench_transpose::<u8>(b, 64, 64); }
-#[bench] fn bench1_u8_0256x0256(b: &mut test::Bencher) { bench_transpose::<u8>(b, 256, 256); }
-#[bench] fn bench1_u8_1024x1024(b: &mut test::Bencher) { bench_transpose::<u8>(b, 1024, 1024); }
-#[bench] fn bench1_u8_4096x4096(b: &mut test::Bencher) { bench_transpose::<u8>(b, 4096, 4096); }
+fn bench_u8(c: &mut Criterion) { bench_transpose::<u8>(c, "u8") }
+fn bench_u32(c: &mut Criterion) { bench_transpose::<u32>(c, "u32") }
+fn bench_u64(c: &mut Criterion) { bench_transpose::<u64>(c, "u64") }
+fn bench_u128(c: &mut Criterion) { bench_transpose::<u128>(c, "u128") }
 
-#[bench] fn bench2_u32_0004x0004(b: &mut test::Bencher) { bench_transpose::<u32>(b, 4, 4); }
-#[bench] fn bench2_u32_0008x0008(b: &mut test::Bencher) { bench_transpose::<u32>(b, 8, 8); }
-#[bench] fn bench2_u32_0016x0016(b: &mut test::Bencher) { bench_transpose::<u32>(b, 16, 16); }
-#[bench] fn bench2_u32_0064x0064(b: &mut test::Bencher) { bench_transpose::<u32>(b, 64, 64); }
-#[bench] fn bench2_u32_0256x0256(b: &mut test::Bencher) { bench_transpose::<u32>(b, 256, 256); }
-#[bench] fn bench2_u32_1024x1024(b: &mut test::Bencher) { bench_transpose::<u32>(b, 1024, 1024); }
-#[bench] fn bench2_u32_4096x4096(b: &mut test::Bencher) { bench_transpose::<u32>(b, 4096, 4096); }
-
-#[bench] fn bench3_u64_0004x0004(b: &mut test::Bencher) { bench_transpose::<u64>(b, 4, 4); }
-#[bench] fn bench3_u64_0008x0008(b: &mut test::Bencher) { bench_transpose::<u64>(b, 8, 8); }
-#[bench] fn bench3_u64_0016x0016(b: &mut test::Bencher) { bench_transpose::<u64>(b, 16, 16); }
-#[bench] fn bench3_u64_0064x0064(b: &mut test::Bencher) { bench_transpose::<u64>(b, 64, 64); }
-#[bench] fn bench3_u64_0256x0256(b: &mut test::Bencher) { bench_transpose::<u64>(b, 256, 256); }
-#[bench] fn bench3_u64_1024x1024(b: &mut test::Bencher) { bench_transpose::<u64>(b, 1024, 1024); }
-#[bench] fn bench3_u64_4096x4096(b: &mut test::Bencher) { bench_transpose::<u64>(b, 4096, 4096); }
-
-#[bench] fn bench4_u128_0004x0004(b: &mut test::Bencher) { bench_transpose::<u128>(b, 4, 4); }
-#[bench] fn bench4_u128_0008x0008(b: &mut test::Bencher) { bench_transpose::<u128>(b, 8, 8); }
-#[bench] fn bench4_u128_0016x0016(b: &mut test::Bencher) { bench_transpose::<u128>(b, 16, 16); }
-#[bench] fn bench4_u128_0064x0064(b: &mut test::Bencher) { bench_transpose::<u128>(b, 64, 64); }
-#[bench] fn bench4_u128_0256x0256(b: &mut test::Bencher) { bench_transpose::<u128>(b, 256, 256); }
-#[bench] fn bench4_u128_1024x1024(b: &mut test::Bencher) { bench_transpose::<u128>(b, 1024, 1024); }
-#[bench] fn bench4_u128_4096x4096(b: &mut test::Bencher) { bench_transpose::<u128>(b, 4096, 4096); }
+criterion_group!(benches, bench_u8, bench_u32, bench_u64, bench_u128);
+criterion_main!(benches);


### PR DESCRIPTION
An option to consider, porting benchmarks to [Criterion](https://crates.io/crates/criterion). It's got both pros and cons so I won't be disappointed if you decide to close.

Pros: 
* Doesn't require Nightly
* Simpler to implement parameterized benchmarks (I parameterized the input sizes here, significantly DRYing up the benchmark)
* Reports upper and lower bounds as well as average time explicitly instead of average and -/+
* Overall more sophisticated statistical sampling 
* Stores benchmark results in `target/criterion`, allowing subsequent runs to highlight regressions or improvements
* Can be configured to calculate throughput to identify most efficient sizes (I've configured throughput in bytes here to make it easy to compare across element sizes)
* Actively developed

Big Con:
* Rather deep dependency tree (80ish crates), all of them need to be recompiled when playing with `RUSTFLAGS` (a limitation of Cargo)

Other cons (non-exhaustive):
* Doesn't run benchmarks in parallel, at least not by default