### PR TITLE
no_std for num-integer dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,11 @@ categories = ["algorithms", "data structures", "no-std"]
 readme = "README.md"
 
 [dependencies]
-num-integer = "0.1"
 strength_reduce = "^0.2.1"
+
+[dependencies.num-integer]
+version = "0.1"
+default-features = false
 
 [dev-dependencies]
 criterion = "0.2"


### PR DESCRIPTION
Per num-integer docs:

https://crates.io/crates/num-integer

The standard library must be disabled manually in the Cargo.toml dependency section.