### PR TITLE
Recursive

### DIFF
--- a/benches/transpose_benchmarks.rs
+++ b/benches/transpose_benchmarks.rs
@@ -8,7 +8,7 @@ use std::mem;
 use std::time::Duration;
 
 fn bench_oop_transpose<T: Copy + Default>(c: &mut Criterion, tyname: &str) {
-    let ref sizes = [(4, 4), (8, 8), (16, 16), (64, 64), (256, 256), (1024, 1024)];
+    let ref sizes = [(4, 4), (8, 8), (16, 16), (64, 64), (256, 256), (1024, 1024), (2048, 2048), (4096, 4096)];
 
     let bench = ParameterizedBenchmark::new(tyname,
         |b, &&(width, height)| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,13 @@
 //! This library supports both in-place and out-of-place transposes. The out-of-place
 //! transpose is much, much faster than the in-place transpose -- the in-place transpose should
 //! only be used in situations where the system doesn't have enough memory to do an out-of-place transpose.
+//!
+//! The out-of-place transpose uses one out of three different algorithms depending on the length of the input array.
+//!
+//! - Small: simple iteration over the array. 
+//! - Medium: divide the array into tiles of fixed size, and process each tile separately. 
+//! - Large: recursively split the array into smaller parts until each part is of a good size for the tiling algorithm, and then transpose each part.  
+
 #![no_std]
 
 extern crate num_integer;

--- a/src/out_of_place.rs
+++ b/src/out_of_place.rs
@@ -2,7 +2,7 @@
 const BLOCK_SIZE: usize = 16;
 const NBR_SEGMENTS: usize = 4;
 
-const SMALL_LEN: usize = 1024;
+const SMALL_LEN: usize = 255;
 const MEDIUM_LEN: usize = 1024*1024;
 
 /// Given an array of size width * height, representing a flattened 2D array,


### PR DESCRIPTION
This adds a recursive transpose algorithm that is much faster for large matrices. 
For square matrices, it starts to help above around 1024x1024 (for both u32 and u64).
On my system I get this, compared to current master:
```
square transposes out-of-place/u32/(2048, 2048)                                                                             
                        time:   [5.6016 ms 5.6100 ms 5.6205 ms]
                        thrpt:  [2.7800 GiB/s 2.7852 GiB/s 2.7894 GiB/s]
                 change:
                        time:   [-63.111% -62.015% -60.681%] (p = 0.00 < 0.05)
                        thrpt:  [+154.33% +163.26% +171.08%]
                        Performance has improved.

square transposes out-of-place/u32/(4096, 4096)                                                                             
                        time:   [22.835 ms 22.869 ms 22.912 ms]
                        thrpt:  [2.7279 GiB/s 2.7330 GiB/s 2.7370 GiB/s]
                 change:
                        time:   [-68.691% -67.808% -66.320%] (p = 0.00 < 0.05)
                        thrpt:  [+196.92% +210.63% +219.40%]
                        Performance has improved.

square transposes out-of-place/u64/(2048, 2048)                                                                             
                        time:   [7.8119 ms 7.8269 ms 7.8463 ms]
                        thrpt:  [3.9828 GiB/s 3.9926 GiB/s 4.0003 GiB/s]
                 change:
                        time:   [-58.438% -56.624% -54.355%] (p = 0.00 < 0.05)
                        thrpt:  [+119.08% +130.54% +140.60%]
                        Performance has improved.

square transposes out-of-place/u64/(4096, 4096)                                                                             
                        time:   [31.852 ms 31.915 ms 31.996 ms]
                        thrpt:  [3.9067 GiB/s 3.9166 GiB/s 3.9244 GiB/s]
                 change:
                        time:   [-58.695% -56.953% -54.753%] (p = 0.00 < 0.05)
                        thrpt:  [+121.01% +132.31% +142.10%]
                        Performance has improved.
```

For medium lengths the speed is the same speed as before. 

For very short lengths is uses the simple direct transpose from the MixedRadixSmall of RustFFT. This gives a minor improvement of 10-15%.
